### PR TITLE
5/add archlens to archlens

### DIFF
--- a/archlens.json
+++ b/archlens.json
@@ -1,9 +1,9 @@
 {
     "$schema": "https://raw.githubusercontent.com/Perlten/Architectural-Lens/master/config.schema.json",
-    "name": "mt-diagrams",
+    "name": "ArchLens",
     "rootFolder": "src",
     "github": {
-        "url": "https://github.com/Perlten/MT-diagrams",
+        "url": "https://github.com/archlens/ArchLens",
         "branch": "master"
     },
     "saveLocation": "./diagrams/",

--- a/archlens.json
+++ b/archlens.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/Perlten/Architectural-Lens/master/config.schema.json",
+    "$schema": "https://raw.githubusercontent.com/archlens/ArchLens/master/config.schema.json",
     "name": "ArchLens",
     "rootFolder": "src",
     "github": {


### PR DESCRIPTION
This pull request addresses the fact that URLs in the config file for ArchLens (in ArchLens) were still pointing to the old repository it was forked from 