### PR TITLE
Issue #4: Now show changes in dependencies relations

### DIFF
--- a/archlens.json
+++ b/archlens.json
@@ -1,10 +1,10 @@
 {
-    "$schema": "https://raw.githubusercontent.com/archlens/ArchLens/master/config.schema.json",
+    "$schema": "config.schema.json",
     "name": "ArchLens",
     "rootFolder": "src",
     "github": {
-        "url": "https://github.com/archlens/ArchLens",
-        "branch": "master"
+        "url": "",
+        "branch": "main"
     },
     "saveLocation": "./diagrams/",
     "views": {

--- a/archlens.json
+++ b/archlens.json
@@ -1,10 +1,10 @@
 {
-    "$schema": "config.schema.json",
+    "$schema": "https://raw.githubusercontent.com/archlens/ArchLens/master/config.schema.json",
     "name": "ArchLens",
     "rootFolder": "src",
     "github": {
-        "url": "",
-        "branch": "main"
+        "url": "https://github.com/archlens/ArchLens",
+        "branch": "master"
     },
     "saveLocation": "./diagrams/",
     "views": {

--- a/devScripts/package_download.py
+++ b/devScripts/package_download.py
@@ -1,0 +1,12 @@
+import subprocess
+
+# Define the path to the requirements.txt file
+requirements_file_path = "requirements.txt"
+
+# Read the packages from the requirements.txt file
+with open(requirements_file_path, 'r') as f:
+    packages = [line.strip() for line in f if line.strip()]
+
+# Install each package
+for package in packages:
+    subprocess.call(["pip", "install", package])

--- a/src/plantuml/plantuml_file_creator.py
+++ b/src/plantuml/plantuml_file_creator.py
@@ -496,6 +496,7 @@ def get_dependency_string(module: BTModule, dependency_module: BTModule):
     config_manager = ConfigManagerSingleton()
     if config_manager.show_dependency_count:
         dependency_count = module.get_dependency_count(dependency_module)
+        print(dependency_count)
         return f": {dependency_count}"
     return ""
 

--- a/src/plantumlv2/pu_manager.py
+++ b/src/plantumlv2/pu_manager.py
@@ -28,7 +28,10 @@ def render_pu(graph: BTGraph, config: dict):
         save_location = os.path.join(
             config["saveLocation"], f"{project_name}-{view_name}"
         )
-        _save_plantuml_str(save_location, plant_uml_str)
+        diff_location = os.path.join(
+            config["saveLocation"], "diff_relation.txt"
+        )
+        _save_plantuml_str(save_location, diff_location, plant_uml_str)
 
 
 def render_diff_pu(local_bt_graph: BTGraph, remote_bt_graph: BTGraph, config: dict):
@@ -139,7 +142,11 @@ title {title}
     return uml_str
 
 
-def _save_plantuml_str(file_name: str, data: str):
+def _save_plantuml_str(file_name: str, diff_name: str, data: str):
+    os.makedirs(os.path.dirname(diff_name), exist_ok=True)
+    if not os.path.exists(diff_name):
+        open(diff_name, 'w').close()
+
     os.makedirs(os.path.dirname(file_name), exist_ok=True)
     with open(file_name, "w") as f:
         f.write(data)

--- a/src/utils/config_manager_singleton.py
+++ b/src/utils/config_manager_singleton.py
@@ -3,6 +3,7 @@ class ConfigManagerSingleton:
 
     show_dependency_count = None
     package_color = None
+    diff_location = None
 
     def __new__(cls):
         if cls._instance is None:
@@ -12,3 +13,4 @@ class ConfigManagerSingleton:
     def setup(self, config: dict):
         self.show_dependency_count = config.get("showDependencyCount", True)
         self.package_color = config.get("packageColor", "#Azure")
+        self.diff_location = config.get("saveLocation", "./diagrams/")


### PR DESCRIPTION
Upon rendering, a file named "diff_relation" should now be generated in the "savelocation" that has been configured. This file contains the relations from the previous build of the view. If a difference from the previous view is detected, a modification of the relation will be added: "+" indicates gained relations, while "-" indicates lost relations.

For reference, please see the picture below which displays the file and diagram. Assigning color to the "+" or "-" has not been prioritized as it requires further research into the BT library, specifically on how to change only a certain part of an edge label.
![image](https://github.com/archlens/ArchLens/assets/38203617/cf7ea52f-b387-4cfd-bead-e547f11804c8)
