### PR TITLE
Add deltas in cardinality of relationships in the diff views  via pu

### DIFF
--- a/src/plantumlv2/pu_entities.py
+++ b/src/plantumlv2/pu_entities.py
@@ -170,5 +170,5 @@ class PuDependency:
             from_name = self.from_package.name
             to_name = self.to_package.name
             return f'"{from_name}"-->"{to_name}" {self.state.value} {dependency_count_str}'
-        else: 
+        else:
             return self.render_diff

--- a/src/plantumlv2/pu_entities.py
+++ b/src/plantumlv2/pu_entities.py
@@ -139,6 +139,8 @@ class PuDependency:
 
     dependency_count = 0
 
+    render_diff = ""
+
     def __init__(
         self,
         from_package: PuPackage,
@@ -160,9 +162,13 @@ class PuDependency:
 
     def render(self) -> str:
         config_manager = ConfigManagerSingleton()
-        dependency_count_str = ""
-        if config_manager.show_dependency_count:
-            dependency_count_str = f": {self.dependency_count}"
-        from_name = self.from_package.name
-        to_name = self.to_package.name
-        return f'"{from_name}"-->"{to_name}" {self.state.value} {dependency_count_str}'
+
+        if not self.render_diff:
+            dependency_count_str = ""
+            if config_manager.show_dependency_count:
+                dependency_count_str = f": {self.dependency_count}"
+            from_name = self.from_package.name
+            to_name = self.to_package.name
+            return f'"{from_name}"-->"{to_name}" {self.state.value} {dependency_count_str}'
+        else: 
+            return self.render_diff

--- a/src/plantumlv2/pu_manager.py
+++ b/src/plantumlv2/pu_manager.py
@@ -77,9 +77,14 @@ def render_diff_pu(local_bt_graph: BTGraph, remote_bt_graph: BTGraph, config: di
                     diff = local_value.dependency_count - remote_value.dependency_count
                     sign = "+" if diff > 0 else ""
                     color = EntityState.CREATED if diff > 0 else EntityState.DELETED
-                    dependency_count = f": {local_value.dependency_count} ({sign}{diff})" if diff != 0 else f": {local_value.dependency_count}"
+                    dependency_count = (
+                        f": {local_value.dependency_count} ({sign}{diff})"
+                        if diff != 0
+                        else f": {local_value.dependency_count}")
 
-                    local_dependency_map[remote_key].render_diff = f'"{local_value.from_package.name}"-->"{local_value.to_package.name}" {color} {dependency_count}'
+                    local_dependency_map[remote_key].render_diff = (
+                        f'"{local_value.from_package.name}"-->"{local_value.to_package.name}" '
+                        f"{color} {dependency_count}")
 
             # Created dependencies
             for dependency_path, dependency in local_dependency_map.items():

--- a/src/plantumlv2/pu_manager.py
+++ b/src/plantumlv2/pu_manager.py
@@ -64,7 +64,6 @@ def render_diff_pu(local_bt_graph: BTGraph, remote_bt_graph: BTGraph, config: di
                 continue  # We have already dealt with this case above
             local_dependency_map = package.get_dependency_map()
             remote_dependency_map = remote_graph[path].get_dependency_map()
-            
             for remote_key, remote_value in remote_dependency_map.items():
                 # Check if the same key exists in the local_dependency_map
                 if remote_key not in local_dependency_map:
@@ -105,7 +104,6 @@ def render_diff_pu(local_bt_graph: BTGraph, remote_bt_graph: BTGraph, config: di
                     package.pu_dependency_list.append(remote_dependency)
 
             diff_graph.append(package)
-        
         plant_uml_str = _render_pu_graph(diff_graph, view_name, config)
         save_location = os.path.join(
             config["saveLocation"], f"{project_name}-diff-{view_name}"


### PR DESCRIPTION
Now uses the remote, and local copy of the graph to differ in the cardinality.
The functionality is now added in the pu_manager as the other diff tools.

To run locally: $ python -m src.cli_interface render-diff