### PR TITLE
Ignorepackages not working

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages, glob
 
 setup(
     name="ArchLens",
-    version="0.2.2",
+    version="0.2.3",
     description="Designed for visualizing package dependencies and highlighting differences between"
     " branches in GitHub pull requests. It offers customization options to tailor package views.",
     author="The ArchLens Team",

--- a/src/views/view_manager.py
+++ b/src/views/view_manager.py
@@ -233,12 +233,14 @@ def _filter_packages(
     # ignorePackages
 
     if not "ignorePackages" in view:
-        view["ignorePackages"] = []
+        view["ignorePackages"] = []        
 
     updated_filtered_packages_set: set = set()
-    for ignore_packages in view["ignorePackages"]:
-        for package in filtered_packages_set:
-            should_filter = False
+    for package in filtered_packages_set:
+        should_filter = False
+
+        for ignore_packages in view["ignorePackages"]:
+            ignore_packages = ignore_packages.replace(".", "/")
             if ignore_packages.startswith("*") and ignore_packages.endswith("*"):
                 if ignore_packages[1:-1] in package.path:
                     should_filter = True
@@ -246,8 +248,8 @@ def _filter_packages(
                 if package.path.startswith(ignore_packages):
                     should_filter = True
 
-            if not should_filter:
-                updated_filtered_packages_set.add(package)
+        if not should_filter:
+            updated_filtered_packages_set.add(package)
 
     if len(view["ignorePackages"]) == 0:
         updated_filtered_packages_set = filtered_packages_set

--- a/src/views/view_manager.py
+++ b/src/views/view_manager.py
@@ -231,6 +231,10 @@ def _filter_packages(
         filtered_packages_set = set(packages_map.values())
 
     # ignorePackages
+
+    if not "ignorePackages" in view:
+        view["ignorePackages"] = []
+
     updated_filtered_packages_set: set = set()
     for ignore_packages in view["ignorePackages"]:
         for package in filtered_packages_set:


### PR DESCRIPTION
ArchLens no longer crashes when a view does not have a specified ignorePackages-field

Modules specified in ignorePackages are now properly filtered and excluded from the view