### PR TITLE
Improve diff visualization with colored triangles and thicker lines

### DIFF
--- a/src/views/view_entities.py
+++ b/src/views/view_entities.py
@@ -196,7 +196,11 @@ class ViewDependancy:
                 f'"{from_name}"-->"{to_name}" {self.state.value} {dependency_count_str}'
             )
         else:
-            return f'"{self.render_diff["from_package"].name}"-->"{self.render_diff["to_package"].name}" {self.render_diff["color"].value} : {self.render_diff["label"]}'
+            color = self.render_diff["color"].value
+            from_name = self.render_diff["from_package"].name
+            to_name = self.render_diff["to_package"].name
+            label = self.render_diff["label"]
+            return f'"{from_name}" -[{color},thickness=2]-> "{to_name}" : {label}'
 
     def render_json(self) -> dict:
         config_manager = ConfigManagerSingleton()

--- a/src/views/view_manager.py
+++ b/src/views/view_manager.py
@@ -96,7 +96,7 @@ def render_diff_views(
                         "from_package": remote_value.from_package,
                         "to_package": remote_value.to_package,
                         "color": color,
-                        "label": f"0 ({dependency_count})",
+                        "label": f"0 <color:red>▼{abs(dependency_count)}</color>",
                     }
                     view_has_changes = True
                     continue
@@ -106,10 +106,13 @@ def render_diff_views(
                 # Check if dependency counts are different
                 if remote_value.dependency_count != local_value.dependency_count:
                     diff = local_value.dependency_count - remote_value.dependency_count
-                    sign = "+" if diff > 0 else ""
                     color = EntityState.CREATED if diff > 0 else EntityState.DELETED
+                    if diff > 0:
+                        diff_indicator = f"<color:green>▲{diff}</color>"
+                    else:
+                        diff_indicator = f"<color:red>▼{abs(diff)}</color>"
                     dependency_count = (
-                        f"{local_value.dependency_count} ({sign}{diff})"
+                        f"{local_value.dependency_count} {diff_indicator}"
                         if diff != 0
                         else f"{local_value.dependency_count}"
                     )
@@ -132,7 +135,7 @@ def render_diff_views(
                         "from_package": dependency.from_package,
                         "to_package": dependency.to_package,
                         "color": color,
-                        "label": f"{dependency_count} (+{dependency_count})",
+                        "label": f"{dependency_count} <color:green>▲{dependency_count}</color>",
                     }
                     view_has_changes = True
 

--- a/src/views/view_manager.py
+++ b/src/views/view_manager.py
@@ -96,7 +96,7 @@ def render_diff_views(
                         "from_package": remote_value.from_package,
                         "to_package": remote_value.to_package,
                         "color": color,
-                        "label": f"0 <color:red>▼{abs(dependency_count)}</color>",
+                        "label": f"0\\n<size:10><b><color:red>(▼{abs(dependency_count)})</color></b></size>",
                     }
                     view_has_changes = True
                     continue
@@ -108,11 +108,11 @@ def render_diff_views(
                     diff = local_value.dependency_count - remote_value.dependency_count
                     color = EntityState.CREATED if diff > 0 else EntityState.DELETED
                     if diff > 0:
-                        diff_indicator = f"<color:green>▲{diff}</color>"
+                        diff_indicator = f"<size:10><b><color:green>(▲{diff})</color></b></size>"
                     else:
-                        diff_indicator = f"<color:red>▼{abs(diff)}</color>"
+                        diff_indicator = f"<size:10><b><color:red>(▼{abs(diff)})</color></b></size>"
                     dependency_count = (
-                        f"{local_value.dependency_count} {diff_indicator}"
+                        f"{local_value.dependency_count}\\n{diff_indicator}"
                         if diff != 0
                         else f"{local_value.dependency_count}"
                     )
@@ -135,7 +135,7 @@ def render_diff_views(
                         "from_package": dependency.from_package,
                         "to_package": dependency.to_package,
                         "color": color,
-                        "label": f"{dependency_count} <color:green>▲{dependency_count}</color>",
+                        "label": f"{dependency_count}\\n<size:10><b><color:green>(▲{dependency_count})</color></b></size>",
                     }
                     view_has_changes = True
 


### PR DESCRIPTION
## Summary
- Replace `(+N)` and `(-N)` dependency change indicators with colored triangle symbols: green ▲ for increases, red ▼ for decreases
- Increase thickness of colored diff lines to 2px for better visibility in GitHub

## Test plan
- [ ] Run `archlens render-diff` on a project with dependency changes
- [ ] Verify triangles appear with correct colors (green up, red down)
- [ ] Verify diff lines are visibly thicker than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)