### PR TITLE
Add file-level dependency visualization support

### DIFF
--- a/src/core/bt_file.py
+++ b/src/core/bt_file.py
@@ -44,6 +44,64 @@ class BTFile:
             return None
         return "/".join(self.file.split("/")[:-1])
 
+    @property
+    def path(self) -> str:
+        """Returns the full file path (used for ViewPackage compatibility)"""
+        if not self.ast:
+            return None
+        return self.ast.file
+
+    @property
+    def depth(self) -> int:
+        """Depth is module depth + 1 (file is one level deeper than its module)"""
+        if self.module:
+            return self.module.depth + 1
+        return 0
+
+    @property
+    def parent_module(self):
+        """Alias for module (ViewPackage compatibility)"""
+        return self.module
+
+    @property
+    def child_module(self) -> list:
+        """Files don't have children"""
+        return []
+
+    @property
+    def name(self) -> str:
+        """Return file name without .py extension"""
+        return self.label.replace(".py", "")
+
+    def get_submodules_recursive(self) -> list:
+        """Files don't have submodules"""
+        return []
+
+    def get_module_dependencies(self) -> set["BTFile"]:
+        """Get all files this file depends on"""
+        return set(self.edge_to)
+
+    def get_file_dependencies(self) -> set["BTFile"]:
+        """Get all files this file depends on (same as get_module_dependencies for files)"""
+        return set(self.edge_to)
+
+    def get_dependency_count(self, other: "BTFile") -> int:
+        """Count how many times this file imports from another file"""
+        if isinstance(other, BTFile):
+            return 1 if other in self.edge_to else 0
+        # If other is a BTModule, count edges to files in that module
+        count = len([e for e in self.edge_to if e.module == other])
+        return count
+
+    def get_file_level_relations(self, target) -> list:
+        """Get file-level relations to target (file or module)"""
+        if isinstance(target, BTFile):
+            if target in self.edge_to:
+                return [(self, target)]
+            return []
+        # If target is a BTModule, get relations to files in that module
+        return [(self, e) for e in self.edge_to if e.module == target]
+
     def __rshift__(self, other):
         if isinstance(other, list):
             existing_edges = set(
@@ -59,20 +117,72 @@ class BTFile:
             self.edge_to.append(other)
 
 
+def _resolve_relative_import(modname: str, level: int, current_file: str) -> str:
+    """
+    Resolve a relative import to an absolute module name.
+
+    Args:
+        modname: The module name from the import (e.g., "prompts" for "from .prompts import ...")
+        level: Number of dots (1 for ".", 2 for "..", etc.)
+        current_file: Path to the file containing the import
+
+    Returns:
+        The absolute module name
+    """
+    import os
+
+    # Get the directory of the current file
+    current_dir = os.path.dirname(current_file)
+
+    # Go up 'level' directories (level=1 means current package, level=2 means parent, etc.)
+    for _ in range(level - 1):
+        current_dir = os.path.dirname(current_dir)
+
+    # Convert path to module format
+    # Find the package name from the directory
+    package_parts = []
+    temp_dir = current_dir
+    while os.path.exists(os.path.join(temp_dir, "__init__.py")):
+        package_parts.insert(0, os.path.basename(temp_dir))
+        parent = os.path.dirname(temp_dir)
+        if parent == temp_dir:  # Reached filesystem root
+            break
+        temp_dir = parent
+
+    base_module = ".".join(package_parts)
+
+    if modname:
+        return f"{base_module}.{modname}" if base_module else modname
+    return base_module
+
+
 def get_imported_modules(
     ast: astroid.Module, root_location: str, am: AstroidManager
 ) -> list:
     imported_modules = []
-    for sub_node in ast.body:
+
+    # Get the file path from the root module (works even when called with nested nodes)
+    root_module = ast.root() if hasattr(ast, 'root') else ast
+    current_file = root_module.file if hasattr(root_module, 'file') else None
+
+    # Use nodes_of_class to find ALL imports in the entire AST tree,
+    # including those inside functions and classes
+    for sub_node in ast.nodes_of_class((astroid.node_classes.ImportFrom, astroid.node_classes.Import)):
         try:
             if isinstance(sub_node, astroid.node_classes.ImportFrom):
-                sub_node: astroid.node_classes.ImportFrom = sub_node
+                modname = sub_node.modname
+                level = sub_node.level if sub_node.level else 0
 
-                module_node = am.ast_from_module_name(
-                    sub_node.modname,
-                    context_file=root_location,
-                )
-                imported_modules.append(module_node)
+                # Handle relative imports
+                if level > 0 and current_file:
+                    modname = _resolve_relative_import(modname or "", level, current_file)
+
+                if modname:
+                    module_node = am.ast_from_module_name(
+                        modname,
+                        context_file=root_location,
+                    )
+                    imported_modules.append(module_node)
 
             elif isinstance(sub_node, astroid.node_classes.Import):
                 for name, _ in sub_node.names:
@@ -84,12 +194,10 @@ def get_imported_modules(
                         imported_modules.append(module_node)
                     except Exception:
                         continue
-            elif hasattr(sub_node, "body"):
-                imported_modules.extend(
-                    get_imported_modules(sub_node, root_location, am)
-                )
 
         except astroid.AstroidImportError:
+            continue
+        except Exception:
             continue
 
     return imported_modules

--- a/src/core/bt_graph.py
+++ b/src/core/bt_graph.py
@@ -104,6 +104,16 @@ class BTGraph:
     def get_all_bt_modules_map(self) -> dict[str, BTModule]:
         return {btm.path: btm for btm in self.root_module.get_submodules_recursive()}
 
+    def get_all_bt_files_as_nodes_map(self) -> dict[str, BTFile]:
+        """Get all files as potential graph nodes, keyed by their path (without .py extension)"""
+        result = {}
+        for btf in self.root_module.get_files_recursive():
+            if btf.file:
+                # Key is file path without .py extension (e.g., "core/llm_services/anthropic_service")
+                key = btf.file.replace(".py", "")
+                result[key] = btf
+        return result
+
     def _get_files_recursive(self, path: str) -> list[str]:
         file_list = []
         t = list(os.walk(path))

--- a/src/views/utils.py
+++ b/src/views/utils.py
@@ -1,8 +1,13 @@
 from src.core.bt_module import BTModule
+from src.core.bt_file import BTFile
 from src.utils.path_manager_singleton import PathManagerSingleton
 
 
-def get_view_package_path_from_bt_package(bt_package: BTModule) -> str:
+def get_view_package_path_from_bt_package(bt_package: BTModule | BTFile) -> str:
     path_manager = PathManagerSingleton()
+    if isinstance(bt_package, BTFile):
+        # For files, use the file path without .py extension
+        raw_name = path_manager.get_relative_path_from_project_root(bt_package.path, True)
+        return raw_name.replace(".py", "")
     raw_name = path_manager.get_relative_path_from_project_root(bt_package.path, True)
     return raw_name

--- a/src/views/view_entities.py
+++ b/src/views/view_entities.py
@@ -196,7 +196,11 @@ class ViewDependancy:
                 f'"{from_name}"-->"{to_name}" {self.state.value} {dependency_count_str}'
             )
         else:
-            return f'"{self.render_diff["from_package"].name}"-->"{self.render_diff["to_package"].name}" {self.render_diff["color"].value} : {self.render_diff["label"]}'
+            color = self.render_diff["color"].value
+            from_name = self.render_diff["from_package"].name
+            to_name = self.render_diff["to_package"].name
+            label = self.render_diff["label"]
+            return f'"{from_name}" -[{color},thickness=2]-> "{to_name}" : {label}'
 
     def render_json(self) -> dict:
         config_manager = ConfigManagerSingleton()

--- a/src/views/view_manager.py
+++ b/src/views/view_manager.py
@@ -96,7 +96,7 @@ def render_diff_views(
                         "from_package": remote_value.from_package,
                         "to_package": remote_value.to_package,
                         "color": color,
-                        "label": f"0 ({dependency_count})",
+                        "label": f"0 <color:red>▼{abs(dependency_count)}</color>",
                     }
                     view_has_changes = True
                     continue
@@ -106,10 +106,13 @@ def render_diff_views(
                 # Check if dependency counts are different
                 if remote_value.dependency_count != local_value.dependency_count:
                     diff = local_value.dependency_count - remote_value.dependency_count
-                    sign = "+" if diff > 0 else ""
                     color = EntityState.CREATED if diff > 0 else EntityState.DELETED
+                    if diff > 0:
+                        diff_indicator = f"<color:green>▲{diff}</color>"
+                    else:
+                        diff_indicator = f"<color:red>▼{abs(diff)}</color>"
                     dependency_count = (
-                        f"{local_value.dependency_count} ({sign}{diff})"
+                        f"{local_value.dependency_count} {diff_indicator}"
                         if diff != 0
                         else f"{local_value.dependency_count}"
                     )
@@ -132,7 +135,7 @@ def render_diff_views(
                         "from_package": dependency.from_package,
                         "to_package": dependency.to_package,
                         "color": color,
-                        "label": f"{dependency_count} (+{dependency_count})",
+                        "label": f"{dependency_count} <color:green>▲{dependency_count}</color>",
                     }
                     view_has_changes = True
 

--- a/src/views/view_manager.py
+++ b/src/views/view_manager.py
@@ -96,7 +96,7 @@ def render_diff_views(
                         "from_package": remote_value.from_package,
                         "to_package": remote_value.to_package,
                         "color": color,
-                        "label": f"0 <color:red>▼{abs(dependency_count)}</color>",
+                        "label": f"0\\n<size:10><b><color:red>(▼{abs(dependency_count)})</color></b></size>",
                     }
                     view_has_changes = True
                     continue
@@ -108,11 +108,11 @@ def render_diff_views(
                     diff = local_value.dependency_count - remote_value.dependency_count
                     color = EntityState.CREATED if diff > 0 else EntityState.DELETED
                     if diff > 0:
-                        diff_indicator = f"<color:green>▲{diff}</color>"
+                        diff_indicator = f"<size:10><b><color:green>(▲{diff})</color></b></size>"
                     else:
-                        diff_indicator = f"<color:red>▼{abs(diff)}</color>"
+                        diff_indicator = f"<size:10><b><color:red>(▼{abs(diff)})</color></b></size>"
                     dependency_count = (
-                        f"{local_value.dependency_count} {diff_indicator}"
+                        f"{local_value.dependency_count}\\n{diff_indicator}"
                         if diff != 0
                         else f"{local_value.dependency_count}"
                     )
@@ -135,7 +135,7 @@ def render_diff_views(
                         "from_package": dependency.from_package,
                         "to_package": dependency.to_package,
                         "color": color,
-                        "label": f"{dependency_count} <color:green>▲{dependency_count}</color>",
+                        "label": f"{dependency_count}\\n<size:10><b><color:green>(▲{dependency_count})</color></b></size>",
                     }
                     view_has_changes = True
 


### PR DESCRIPTION
## Summary
- Enable showing individual Python files as nodes in architecture diagrams (not just packages/modules)
- Add new `files` config key to explicitly include specific files as nodes
- Files render as white rectangles with `.py` suffix to distinguish from packages
- Strip common prefix from all node labels and show it in the diagram title for cleaner visualization

## Technical Changes
- **bt_file.py**: Add ViewPackage compatibility (path, depth, name properties), resolve relative imports (`from .module import`), detect imports inside functions/classes using `nodes_of_class()`
- **bt_graph.py**: Add `get_all_bt_files_as_nodes_map()` method
- **view_entities.py**: Make `ViewPackage` polymorphic to accept both `BTModule` and `BTFile`, add parent-path fallback for dependency matching
- **view_manager.py**: Add `_get_requested_files()` helper, only create file nodes when explicitly requested
- **pu_render.py**: Extract common prefix from node names and display in title

## Example Config
```json
"llm-services-files": {
  "packages": ["core.llm_services.prompts"],
  "files": [
    "core.llm_services.anthropic_service",
    "core.llm_services.llm_service"
  ]
}
```

## Test plan
- [x] Verify existing package-only views still render correctly
- [x] Verify new file nodes appear with `.py` suffix and white background
- [x] Verify dependencies from files to packages are detected
- [x] Verify relative imports inside functions are detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)